### PR TITLE
Fix CI: vendor fleet tsconfig (no private dotagents clone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout dotagents tsconfig baseline
-        uses: actions/checkout@v4
-        with:
-          repository: jsolly/dotagents
-          path: ../dotagents
-          sparse-checkout: tsconfig
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../dotagents/tsconfig/strict-tsc.json",
+  "extends": "./tsconfig/fleet/strict-tsc.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,

--- a/tsconfig/fleet/strict-tsc.json
+++ b/tsconfig/fleet/strict-tsc.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false
+	}
+}


### PR DESCRIPTION
## Summary
- Vendor `tsconfig/fleet/strict-tsc.json`; simplify CI workflow.

## Test plan
- [ ] CI / ci green

Made with [Cursor](https://cursor.com)