### PR TITLE
ci: bump checkout@v7 + setup-node@v6 off Node-20 pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
Bumps `actions/checkout@v4`→`@v7` and `actions/setup-node@v4`→`@v6` — both were on the deprecated Node 20 runtime (GitHub forces Node 24 with a warning).

Changelog-checked against this workflow: checkout v7's only behavioral change blocks fork checkout for `pull_request_target`/`workflow_run` (this workflow uses `pull_request`+`push` — unaffected); setup-node v6 limits auto-caching to npm (`cache: npm` already set — unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)